### PR TITLE
Allow Criterion group separator in name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supported sources:
 
 ## Metadata format
 
-The benchmark name in the `cargo` benchmarks can be provided as a `,`-separated string where each item represents a key-value pair with the format `key=value`, e.g. `category=ML-KEM,keySize=44,name=PK Validation,platform=neon,api=unpacked`.
+The benchmark name in the `cargo` benchmarks can be provided as a `,`-separated string where each item represents a key-value pair with the format `key=value`, e.g. `category=ML-KEM,keySize=44,name=PK Validation,platform=neon,api=unpacked`. Additionally, one of these separators may be a `/`, where the left-hand side represents the keys configured for a Criterion group. In that case, the right-hand side represents the keys for a benchmark function on that group, e.g. `category=ML-KEM,keySize=44,name=PK Validation/platform=neon,api=unpacked`. Aside from this separator, no other `/` characters should be included in the name.
 
 Alternatively, the benchmark name can be provided as a simple string, which will then be set as the value of the `name` key. This will only happen if there are no `key=value` pairs found in the benchmark name.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supported sources:
 
 ## Metadata format
 
-The benchmark name in the `cargo` benchmarks can be provided as a `,`-separated string where each item represents a key-value pair with the format `key=value`, e.g. `category=ML-KEM,keySize=44,name=PK Validation,platform=neon,api=unpacked`. Additionally, one of these separators may be a `/`, where the left-hand side represents the keys configured for a Criterion group. In that case, the right-hand side represents the keys for a benchmark function on that group, e.g. `category=ML-KEM,keySize=44,name=PK Validation/platform=neon,api=unpacked`. Aside from this separator, no other `/` characters should be included in the name.
+The benchmark name in the `cargo` benchmarks can be provided as a `,`-separated string where each item represents a key-value pair with the format `key=value`, e.g. `category=ML-KEM,keySize=44,name=PK Validation,platform=neon,api=unpacked`. Additionally, one of these separators may be a `/`, where the left-hand side represents the keys configured for a Criterion group, and the right-hand side represents the keys for a benchmark function on that group, e.g. `category=ML-KEM,keySize=44,name=PK Validation/platform=neon,api=unpacked`. Aside from this separator, no other `/` characters should be included in the name.
 
 Alternatively, the benchmark name can be provided as a simple string, which will then be set as the value of the `name` key. This will only happen if there are no `key=value` pairs found in the benchmark name.
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -50,7 +50,7 @@ cp -R node_modules .release/node_modules
 
 git checkout "$version"
 git pull
-git rm -rf node_modules
+git rm -rf --ignore-unmatch node_modules
 rm -rf node_modules  # remove node_modules/.cache
 
 rm -rf dist

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -14,8 +14,14 @@ export interface BenchmarkResult {
 }
 
 function addNameMetadataToResult(result: BenchmarkResult, nameString: string) {
-    // split by separator
-    const keyValuePairs = nameString.split(',');
+    // replace first '/'
+    // only one is allowed, as a Criterion group/function separator
+    const nameStringProcessed = nameString.replace('/', ',');
+
+    if (nameStringProcessed.includes('/')) {
+        throw new Error("Only one '/' is allowed as a group/function separator");
+    }
+    const keyValuePairs = nameStringProcessed.split(',');
 
     let foundAtLeastOne = false;
 

--- a/test/data/extract/criterion_invalid.txt
+++ b/test/data/extract/criterion_invalid.txt
@@ -4,7 +4,7 @@ This feature is being moved to cargo-criterion (https://github.com/bheisler/carg
 Gnuplot not found, using plotters backend
 test category=ML-KEM,keySize=1024,name=PK Validation ... bench:         329 ns/iter (+/- 4)
 
-test category=ML-KEM,keySize=512,name=PK Validation/platform=neon,api=unpacked ... bench:        3268 ns/iter (+/- 47)
+test category=ML-KEM,keySize=512/name=PK Validation/platform=neon,api=unpacked ... bench:        3268 ns/iter (+/- 47)
 
 test category=ML-KEM,keySize=768,name=PK Validation/platform=neon,api=unpacked ... bench:       12314 ns/iter (+/- 123)
 

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -82,6 +82,15 @@ describe('extractData()', function () {
         } as Config;
         await A.rejects(extractData(config), /^Error: No benchmark result was found in /);
     });
+
+    it('raises an error when more than one / separator', async function () {
+        const config = {
+            os: 'ubuntu-latest',
+            tool: 'cargo',
+            outputFilePath: path.join(__dirname, 'data', 'extract', 'criterion_invalid.txt'),
+        } as Config;
+        await A.rejects(extractData(config), /^Error: Only one '\/' is allowed as a group\/function separator/);
+    });
 });
 
 describe('localWriteBenchmark()', function () {


### PR DESCRIPTION
This PR makes a small improvement to the benchmark name format that is accepted by this action. Specifically, this PR adapts the format parsing to allow for one `/` separator between the `key=value` entries in the name, to indicate which keys correspond to a Criterion group, and therefore to match the output format of Criterion benchmarks that are built using groups.

The PR also adds test cases and data for this new functionality.

This PR also includes a bugfix for the release script, which avoids `git rm -rf` returning an error when node_modules have not been added to a branch yet. 